### PR TITLE
Update base href to be blank

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>CapsulesApp</title>
-  <base href="capsules-app">
+  <base href="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>CapsulesApp</title>
-  <base href="capsules-app">
+  <base href="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
Project was intially built with the following command

```
ng build --prod --base-href "/capsules-app/"
```

which resulted in the url being /capsules-app/capsules-app. Built without specifying a base href ("") which will fix this issue